### PR TITLE
Implemented session modification on the backend side

### DIFF
--- a/client/src/components/new-testcase-view.tsx
+++ b/client/src/components/new-testcase-view.tsx
@@ -1,0 +1,149 @@
+import * as React from 'react';
+import { Button, ButtonOr, Form, ButtonGroup, Input, FormTextArea, Checkbox, InputProps, CheckboxProps } from 'semantic-ui-react';
+import { Testcase } from '../api/v1/session_pb';
+import { AppStateContent, getClient } from 'src/types/app-state';
+
+export interface NewTestcaseViewProps {
+    appState: AppStateContent;
+    testcase?: Testcase;
+    onClose: () => void;
+}
+
+interface NewTestcaseViewState {
+    id?: string;
+    group?: string;
+    name?: string;
+    mustPass?: boolean;
+    minTesterCount?: number;
+    description?: string;
+    steps?: string;
+}
+
+export class NewTestcaseView extends React.Component<NewTestcaseViewProps, NewTestcaseViewState> {
+    protected focusElement: any | undefined;
+
+    constructor(props: NewTestcaseViewProps) {
+        super(props);
+
+        if (this.props.testcase) {
+            this.state = {
+                id: this.props.testcase.getId(),
+                group: this.props.testcase.getGroup(),
+                name: this.props.testcase.getName(),
+                mustPass: this.props.testcase.getMustpass(),
+                minTesterCount: this.props.testcase.getMintestercount(),
+                description: this.props.testcase.getDescription(),
+                steps: this.props.testcase.getSteps(),
+            }
+        } else {
+            this.state = {
+                minTesterCount: 1,
+                mustPass: true
+            }
+        }
+
+        this.setFocusElement = this.setFocusElement.bind(this);
+        this.onCancel = this.onCancel.bind(this);
+        this.onSubmit = this.onSubmit.bind(this);
+        this.onChange = this.onChange.bind(this);
+    }
+
+    public componentDidMount(){
+        if (this.focusElement) {
+            // this.focusElement.focus();
+        }
+    }
+
+    public render() {
+        return (
+            <Form>
+                <Form.Field>
+                    <label>ID</label>
+                    <Input disabled={!!this.props.testcase} type="text" value={this.state.id} placeholder="name" onChange={this.onChange.bind(this, "id")} />
+                </Form.Field>
+                <Form.Field>
+                    <label>Group</label>
+                    <Input type="text" value={this.state.group} placeholder="name" onChange={this.onChange.bind(this, "group")} />
+                </Form.Field>
+                <Form.Field>
+                    <label>Name</label>
+                    <Input type="text" value={this.state.name} placeholder="name" onChange={this.onChange.bind(this, "name")} />
+                </Form.Field>
+                <Form.Field>
+                    <label>Minimum Tester Count</label>
+                    <Input type="text" value={this.state.minTesterCount} placeholder="name" onChange={this.onChange.bind(this, "minTesterCount")} />
+                </Form.Field>
+                <Form.Field>
+                    <Checkbox toggle={true} label="Must pass" checked={this.state.mustPass} onChange={this.onChange.bind(this, "mustPass")} />
+                </Form.Field>
+                <Form.Field>
+                    <label>Description</label>
+                    <FormTextArea content={this.state.description} onChange={this.onChange.bind(this, "description")} />
+                </Form.Field>
+                <Form.Field>
+                    <label>Steps</label>
+                    <FormTextArea content={this.state.steps} onChange={this.onChange.bind(this, "steps")} />
+                </Form.Field>
+
+                <ButtonGroup>
+                    <Button positive={true} onClick={this.onSubmit} fluid={true}>Submit</Button>
+                    <ButtonOr />
+                    <Button onClick={this.onCancel}>Cancel</Button>
+                </ButtonGroup>
+            </Form>
+        );
+    }
+
+    protected setFocusElement(element: any) {
+        this.focusElement = element;
+    }
+
+    protected async onSubmit() {
+        const tc = new Testcase();
+        tc.setId(this.state.id || "");
+        tc.setGroup(this.state.group || "");
+        tc.setName(this.state.name || "");
+        tc.setMintestercount(this.state.minTesterCount || 0);
+        tc.setMustpass(!!this.state.mustPass);
+        tc.setDescription(this.state.description || "");
+        tc.setSteps(this.state.steps || "");
+
+        if (!!this.props.testcase) {
+            tc.setId(this.props.testcase.getId());
+            try {
+                await getClient(this.props.appState).modifyTestcase(tc);
+                this.props.onClose();
+            } catch (err) {
+                this.props.appState.setError(err);
+            }
+        } else {
+            try {
+                await getClient(this.props.appState).addTestcase(tc);
+                this.props.onClose();
+            } catch (err) {
+                this.props.appState.setError(err);
+            }
+        }
+    }
+
+    protected onCancel() {
+        this.props.onClose();
+    }
+
+    protected onChange(field: string, evt: React.SyntheticEvent, props: any) {
+        if (field === "minTesterCount") {
+            const n = parseInt((props as InputProps).value, 10);
+            if (!Number.isNaN(n)) {
+                this.setState({ minTesterCount: n });
+            }
+        } else if (field === "mustPass") {
+            this.setState({ mustPass: !!(props as CheckboxProps).value });
+        } else {
+            const val = (props as InputProps).value;
+            const s: any = {};
+            s[field] = val;
+            this.setState(s);
+        }
+    }
+
+}

--- a/client/src/components/testplan-view.tsx
+++ b/client/src/components/testplan-view.tsx
@@ -102,7 +102,7 @@ export class TestplanView extends React.Component<TestplanViewProps, TestplanVie
             return [];
         }
 
-        const cases = this.state.status.getStatusList();
+        const cases = this.state.status.getCaseList();
         if (!cases) {
             console.warn("Session has empty case list");
             return [];

--- a/client/src/types/service-client.ts
+++ b/client/src/types/service-client.ts
@@ -3,7 +3,7 @@ import { grpc } from 'grpc-web-client';
 import { UserService } from '../api/v1/user_pb_service';
 import { ProtobufMessage } from 'grpc-web-client/dist/typings/message';
 import { MethodDefinition } from 'grpc-web-client/dist/typings/service';
-import { ClaimRequest, TestRunState, ContributionRequest, TestRunStatus, SessionStatusRequest, SessionStatusResponse, SessionUpdatesRequest, SessionUpdateResponse, RegistrationRequest } from '../api/v1/session_pb';
+import { ClaimRequest, TestRunState, ContributionRequest, TestRunStatus, SessionStatusRequest, SessionStatusResponse, SessionUpdatesRequest, SessionUpdateResponse, RegistrationRequest, Testcase, ModifySessionRequest, Modification } from '../api/v1/session_pb';
 import { SessionService } from '../api/v1/session_pb_service';
 import { AppStateContent, getAuthentication } from './app-state';
 
@@ -96,6 +96,30 @@ export class Client {
         const listener = new UpdateListener(this.host, getAuthentication(this.appState)!, callback);
         await listener.start(this.appState.session!);
         return listener;
+    }
+
+    public async modifyTestcase(tc: Testcase): Promise<void> {
+        const req = new ModifySessionRequest();
+        req.setModification(Modification.MODIFY_TESTCASE);
+        req.setId(this.appState.session!);
+        req.addCase(tc);
+        await this.invoke(SessionService.Modify, req);
+    }
+
+    public async addTestcase(tc: Testcase): Promise<void> {
+        const req = new ModifySessionRequest();
+        req.setModification(Modification.ADD_TESTCASE);
+        req.setId(this.appState.session!);
+        req.addCase(tc);
+        await this.invoke(SessionService.Modify, req);
+    }
+
+    public async removeTestcase(tc: Testcase): Promise<void> {
+        const req = new ModifySessionRequest();
+        req.setModification(Modification.REMOVE_TESTCASE);
+        req.setId(this.appState.session!);
+        req.addCase(tc);
+        await this.invoke(SessionService.Modify, req);
     }
 
     protected async invoke<Response, TRequest extends ProtobufMessage, TResponse extends ProtobufMessage, M extends MethodDefinition<TRequest, TResponse>>(methodDescriptor: M, req: TRequest, options?: InvokeOptions<Response, TResponse>): Promise<Response | undefined> {

--- a/cmd/sessionDescribe.go
+++ b/cmd/sessionDescribe.go
@@ -15,8 +15,8 @@ Annotations:	{{ range $k, $v := .Annotations }}{{ $k }}:	{{ $v }}
 	{{ end -}}
 {{ end }}
 Tests:
-{{- range .Status }}
-  {{ .Case.ID }}:
+{{- range .Case }}
+  {{ .Case.Id }}:
     Name:	{{ .Case.Name }}
     Result:	{{ .State }}
     Claims:	{{ len .Claim -}}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -70,7 +70,7 @@ var startCmd = &cobra.Command{
 		}
 
 		viper.Set("cli.token", token)
-		sessionStart := sessionStartFlags{planfn: args[0], quiet: true}
+		sessionStart := sessionStartFlags{planfn: args[0], quiet: true, modifiable: true}
 		if err := sessionStart.Run(); err != nil {
 			log.WithError(err).Fatal("Cannot start session")
 		}

--- a/examples/users.yaml
+++ b/examples/users.yaml
@@ -6,6 +6,20 @@ permissions:
 - user.grant
 - user.delete
 - user.chpwd
+- session.start
+- session.contribute
+- session.view
+- session.modify
+- session.close
+---
+username: useradmin
+password: useradmin
+email: user-admin-user@ruruku.sh
+permissions:
+- user.add
+- user.grant
+- user.delete
+- user.chpwd
 ---
 username: test-manager
 password: test-manager

--- a/pkg/api/v1/convert.go
+++ b/pkg/api/v1/convert.go
@@ -73,15 +73,15 @@ func (s *TestcaseStatus) Convert() types.TestcaseStatus {
 }
 
 func (s *TestRunStatus) Convert() types.TestRunStatus {
-	status := make([]types.TestcaseStatus, len(s.Status))
-	for i, c := range s.Status {
-		status[i] = c.Convert()
+	cases := make([]types.TestcaseStatus, len(s.Case))
+	for i, c := range s.Case {
+		cases[i] = c.Convert()
 	}
 	return types.TestRunStatus{
 		ID:          s.Id,
 		Name:        s.Name,
 		PlanID:      s.PlanID,
-		Status:      status,
+		Cases:       cases,
 		State:       s.State.Convert(),
 		Annotations: s.Annotations,
 	}
@@ -161,6 +161,9 @@ func (s Permission) Convert() types.Permission {
 	if s == Permission_SESSION_CONTRIBUTE {
 		return types.PermissionSessionContribute
 	}
+	if s == Permission_SESSION_MODIFY {
+		return types.PermissionSessionModify
+	}
 	return types.PermissionNone
 }
 
@@ -191,6 +194,9 @@ func ConvertPermission(s types.Permission) Permission {
 	}
 	if s == types.PermissionSessionContribute {
 		return Permission_SESSION_CONTRIBUTE
+	}
+	if s == types.PermissionSessionModify {
+		return Permission_SESSION_MODIFY
 	}
 	return Permission_NONE
 }

--- a/pkg/api/v1/session.proto
+++ b/pkg/api/v1/session.proto
@@ -6,6 +6,9 @@ service SessionService {
     // Start begins a new test run session
     rpc Start(StartSessionRequest) returns (StartSessionResponse) {}
 
+    // Modify modifies the testcases/metadata of a session
+    rpc Modify(ModifySessionRequest) returns (ModifySessionResponse) {}
+
     // Close closes a session so that no further participation is possible
     rpc Close(CloseSessionRequest) returns (CloseSessionResponse) {}
 
@@ -38,12 +41,34 @@ message StartSessionRequest {
     TestPlan plan = 2;
     // Annotations are key-value pairs containing metadata of the test session
     map<string, string> annotations = 3;
+    // Modifiable controls if the session can be modified while it's open
+    bool modifiable = 4;
 }
 
 message StartSessionResponse {
     // ID is the unique session ID required for participating
     string id = 1;
 }
+
+message ModifySessionRequest {
+    // ID of the session to modify
+    string id = 1;
+    // Modification denotes which kind of operation should be performed
+    Modification modification = 2;
+    // The new complete set of testcases
+    repeated Testcase case = 3;
+    // The new set of annotations
+    map<string, string> annotations = 4;
+}
+
+enum Modification {
+    UPDATE_ANNOTATIONS = 0;
+    ADD_TESTCASE = 10;
+    MODIFY_TESTCASE = 11;
+    REMOVE_TESTCASE = 12;
+}
+
+message ModifySessionResponse {}
 
 message CloseSessionRequest {
     // ID of the session to close
@@ -115,7 +140,6 @@ message SessionUpdateResponse {
     TestRunStatus status = 2;
 }
 
-
 message Participant {
     // Name of the participant. Must be unique among all participants
     string name = 1;
@@ -173,12 +197,14 @@ message TestRunStatus {
     string planID = 3;
     // Open denotes if participants can still join and contribute
     bool open = 4;
+    // Modifiable controls if session can be modified while it's open
+    bool modifiable = 5;
     // Annotations are key-value pairs containing metadata of the test session
-    map<string, string> annotations = 5;
+    map<string, string> annotations = 6;
     // Status lists the status for each testcase of the plan
-    repeated TestcaseStatus status = 6;
+    repeated TestcaseStatus case = 7;
     // State is the overall test run state
-    TestRunState state = 7;
+    TestRunState state = 8;
 }
 
 message TestPlan {

--- a/pkg/api/v1/user.proto
+++ b/pkg/api/v1/user.proto
@@ -37,6 +37,7 @@ enum Permission {
     SESSION_CLOSE = 11;
     SESSION_VIEW = 12; // list, status, updates
     SESSION_CONTRIBUTE = 13; // register, claim, contribute
+    SESSION_MODIFY = 14;
 }
 
 message AuthenticationRequest {

--- a/pkg/server/kvsession/claim_test.go
+++ b/pkg/server/kvsession/claim_test.go
@@ -62,13 +62,13 @@ func TestValidClaim(t *testing.T) {
 		t.Errorf("Cannot get status: %v", err)
 		return
 	}
-	status := statusResp.Status.Status
-	sort.Slice(status, func(i, j int) bool { return status[i].Case.Id < status[j].Case.Id })
+	cases := statusResp.Status.Case
+	sort.Slice(cases, func(i, j int) bool { return cases[i].Case.Id < cases[j].Case.Id })
 
-	if len(status[0].Claim) == 0 {
+	if len(cases[0].Claim) == 0 {
 		t.Errorf("Claim did not register test case claim")
 	}
-	claims := status[0].Claim
+	claims := cases[0].Claim
 	sort.Slice(claims, func(i, j int) bool { return claims[i].Name < claims[j].Name })
 	if len(claims) < 2 {
 		t.Errorf("Claim returned wrong number of claims: %d instead of 2", len(claims))
@@ -98,15 +98,15 @@ func TestValidClaim(t *testing.T) {
 		t.Errorf("Cannot get status: %v", err)
 		return
 	}
-	status = statusResp.Status.Status
-	sort.Slice(status, func(i, j int) bool { return status[i].Case.Id < status[j].Case.Id })
-	if len(status) < 2 {
-		t.Errorf("Status returned wrong number of testcases: %d instead of 2", len(status))
+	cases = statusResp.Status.Case
+	sort.Slice(cases, func(i, j int) bool { return cases[i].Case.Id < cases[j].Case.Id })
+	if len(cases) < 2 {
+		t.Errorf("Status returned wrong number of testcases: %d instead of 2", len(cases))
 	} else {
-		if len(status[0].Claim) != 1 {
+		if len(cases[0].Claim) != 1 {
 			t.Errorf("Claim did not unregister previous claim")
 		} else {
-			if status[0].Claim[0].Name != "user01" {
+			if cases[0].Claim[0].Name != "user01" {
 				t.Errorf("Claim unregistered the wrong claim")
 			}
 		}

--- a/pkg/server/kvsession/contribute_test.go
+++ b/pkg/server/kvsession/contribute_test.go
@@ -79,9 +79,9 @@ func TestValidContribution(t *testing.T) {
 		t.Errorf("Cannot get status: %v", err)
 		return
 	}
-	status := statusResp.Status.Status
-	sort.Slice(status, func(i, j int) bool { return status[i].Case.Id < status[j].Case.Id })
-	contributions := status[0].Result
+	cases := statusResp.Status.Case
+	sort.Slice(cases, func(i, j int) bool { return cases[i].Case.Id < cases[j].Case.Id })
+	contributions := cases[0].Result
 	if len(contributions) == 0 {
 		t.Errorf("Contribute did not record contribution")
 		return
@@ -109,9 +109,9 @@ func TestValidContribution(t *testing.T) {
 		t.Errorf("Cannot get status: %v", err)
 		return
 	}
-	status = statusResp.Status.Status
-	sort.Slice(status, func(i, j int) bool { return status[i].Case.Id < status[j].Case.Id })
-	contributions = status[0].Result
+	cases = statusResp.Status.Case
+	sort.Slice(cases, func(i, j int) bool { return cases[i].Case.Id < cases[j].Case.Id })
+	contributions = cases[0].Result
 	if len(contributions) == 0 {
 		t.Errorf("Contribute did not record contribution")
 		return

--- a/pkg/server/kvsession/modify_test.go
+++ b/pkg/server/kvsession/modify_test.go
@@ -1,0 +1,385 @@
+package kvsession
+
+import (
+	"testing"
+
+	"google.golang.org/grpc/codes"
+
+	api "github.com/32leaves/ruruku/pkg/api/v1"
+	"github.com/32leaves/ruruku/pkg/types"
+	"github.com/golang/mock/gomock"
+)
+
+// positive:
+// modifiy annotations: TestValidModifyAnnotations
+// modify existing testcase: TestValidModifyTestcase
+// add testcase: TestValidAddTestcase
+// delete testcase: TestValidModifyRemoveTestcase
+
+// negative:
+// without authentication: not needed - checked by the reqval context mock
+// without authorization: not needed - checked by the reqval context mock
+// modify closed session: TestModifyClosedSession
+// modify unmodifiable session: TestModifyUnmodifiableSession
+// modify non-existing session: TestModifyNonExistentSession
+// modify non-existing testcase: TestModifyNonExistentTestcase
+// modify to invalid testcase: TestModifyToInvalidTestcase
+// add testcase with existing ID: TestModifyInvalidAddTestcase
+// remove non-existent testcase: TestRemoveNonExistentTestcase
+
+func TestValidModifyAnnotations(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mod := func(s *modificationTest) {
+		mreq := &api.ModifySessionRequest{
+			Id:           s.SessionID,
+			Modification: api.Modification_UPDATE_ANNOTATIONS,
+			Annotations:  map[string]string{"foo": "bar", "testing": "this"},
+		}
+		resp, err := s.Server.Modify(s.Reqval.GetContext(s.User, types.PermissionSessionModify), mreq)
+		if err != nil {
+			t.Errorf("Modify returned an error despite valid request: %v", err)
+		}
+		if resp == nil {
+			t.Errorf("Modify did not return a response despite valid request")
+		}
+	}
+	val := func(s *modificationTest) {
+		na := s.Status.Status.Annotations
+		if v, ok := na["foo"]; !ok || v != "bar" {
+			t.Errorf("Modifiy did not update annotations: expected foo=bar")
+		}
+		if v, ok := na["testing"]; !ok || v != "this" {
+			t.Errorf("Modifiy did not update annotations: expected foo=bar")
+		}
+		if len(na) != 2 {
+			t.Errorf("Modify did not update all annotations. expected two annotations, actual: %v", na)
+		}
+	}
+	testModification(t, ctrl, mod, val)
+}
+
+func TestValidModifyTestcase(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var casemod *api.Testcase
+	mod := func(s *modificationTest) {
+		casemod = s.SessionReq.Plan.Case[0]
+		casemod.Description = "foobar this is a change"
+		mreq := &api.ModifySessionRequest{
+			Id:           s.SessionID,
+			Modification: api.Modification_MODIFY_TESTCASE,
+			Case:         []*api.Testcase{casemod},
+		}
+		resp, err := s.Server.Modify(s.Reqval.GetContext(s.User, types.PermissionSessionModify), mreq)
+		if err != nil {
+			t.Errorf("Modify returned an error despite valid request: %v", err)
+		}
+		if resp == nil {
+			t.Errorf("Modify did not return a response despite valid request")
+		}
+	}
+	val := func(s *modificationTest) {
+		var tc00 *api.TestcaseStatus
+		for _, tc := range s.Status.Status.Case {
+			if tc.Case.Id == "tc00" {
+				tc00 = tc
+				break
+			}
+		}
+
+		if tc00 == nil {
+			t.Errorf("Status did not return tc00")
+			return
+		}
+
+		if len(tc00.Claim) != 1 {
+			t.Errorf("Modify did not preserve testcase claim: %d claims expected, %d claims actual", 1, len(tc00.Claim))
+		} else if tc00.Claim[0].Name != s.User {
+			t.Errorf("Modify broke testcase claim: %s expected, %s actual", s.User, tc00.Claim[0].Name)
+		}
+		if tc00.Case.Description != casemod.Description {
+			t.Errorf("Modify did not update testcase in modify_testcase operation")
+		}
+	}
+	testModification(t, ctrl, mod, val)
+}
+
+func TestValidAddTestcase(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var casemod *api.Testcase
+	mod := func(s *modificationTest) {
+		casemod = s.SessionReq.Plan.Case[0]
+		casemod.Id = "yet_another_one"
+		casemod.Description = "foobar this is a change"
+		mreq := &api.ModifySessionRequest{
+			Id:           s.SessionID,
+			Modification: api.Modification_ADD_TESTCASE,
+			Case:         []*api.Testcase{casemod},
+		}
+		resp, err := s.Server.Modify(s.Reqval.GetContext(s.User, types.PermissionSessionModify), mreq)
+		if err != nil {
+			t.Errorf("Modify returned an error despite valid request: %v", err)
+		}
+		if resp == nil {
+			t.Errorf("Modify did not return a response despite valid request")
+		}
+	}
+	val := func(s *modificationTest) {
+		var tc00 *api.TestcaseStatus
+		var tcYAT *api.TestcaseStatus
+		for _, tc := range s.Status.Status.Case {
+			if tc.Case.Id == "tc00" {
+				tc00 = tc
+			}
+			if tc.Case.Id == casemod.Id {
+				tcYAT = tc
+			}
+		}
+
+		if tc00 == nil {
+			t.Errorf("Status did not return tc00")
+		} else {
+			if len(tc00.Claim) != 1 {
+				t.Errorf("Modify did not preserve testcase claim: %d claims expected, %d claims actual", 1, len(tc00.Claim))
+			} else if tc00.Claim[0].Name != s.User {
+				t.Errorf("Modify broke testcase claim: %s expected, %s actual", s.User, tc00.Claim[0].Name)
+			}
+		}
+
+		if tcYAT == nil {
+			t.Errorf("Modify did not add testcase")
+		}
+	}
+	testModification(t, ctrl, mod, val)
+}
+
+func TestValidModifyRemoveTestcase(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var casemod *api.Testcase
+	mod := func(s *modificationTest) {
+		casemod = s.SessionReq.Plan.Case[0]
+		mreq := &api.ModifySessionRequest{
+			Id:           s.SessionID,
+			Modification: api.Modification_REMOVE_TESTCASE,
+			Case:         []*api.Testcase{casemod},
+		}
+		resp, err := s.Server.Modify(s.Reqval.GetContext(s.User, types.PermissionSessionModify), mreq)
+		if err != nil {
+			t.Errorf("Modify returned an error despite valid request: %v", err)
+		}
+		if resp == nil {
+			t.Errorf("Modify did not return a response despite valid request")
+		}
+	}
+	val := func(s *modificationTest) {
+		var tc00 *api.TestcaseStatus
+		for _, tc := range s.Status.Status.Case {
+			if tc.Case.Id == casemod.Id {
+				tc00 = tc
+				break
+			}
+		}
+
+		if tc00 != nil {
+			t.Errorf("Modify did not remove the testcase")
+			return
+		}
+	}
+	testModification(t, ctrl, mod, val)
+}
+
+func TestModifyClosedSession(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mod := func(s *modificationTest) {
+		if _, err := s.Server.Close(s.Reqval.GetContext(s.User, types.PermissionSessionClose), &api.CloseSessionRequest{Id: s.SessionID}); err != nil {
+			t.Errorf("Cannot close session: %v", err)
+			return
+		}
+
+		tc := s.SessionReq.Plan.Case[0]
+		mreq := &api.ModifySessionRequest{
+			Id:           s.SessionID,
+			Modification: api.Modification_MODIFY_TESTCASE,
+			Case:         []*api.Testcase{tc},
+		}
+		resp, err := s.Server.Modify(s.Reqval.GetContext(s.User, types.PermissionSessionModify), mreq)
+		testNegativeResponse(t, "Modify", codes.FailedPrecondition, resp == nil, err)
+	}
+	testModification(t, ctrl, mod, func(s *modificationTest) {})
+}
+
+func TestModifyUnmodifiableSession(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	s, reqval := newTestServer(ctrl)
+
+	user := "user"
+	sreq := validStartSessionRequest()
+	sreq.Modifiable = false
+	sresp, err := s.Start(reqval.GetContext(user, types.PermissionSessionStart), sreq)
+	if err != nil {
+		t.Errorf("Cannot start session: %v", err)
+		return
+	}
+
+	tc := sreq.Plan.Case[0]
+	mreq := &api.ModifySessionRequest{
+		Id:           sresp.Id,
+		Modification: api.Modification_MODIFY_TESTCASE,
+		Case:         []*api.Testcase{tc},
+	}
+	resp, err := s.Modify(reqval.GetContext(user, types.PermissionSessionModify), mreq)
+	testNegativeResponse(t, "Modify", codes.PermissionDenied, resp == nil, err)
+}
+
+func TestModifyNonExistentSession(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mod := func(s *modificationTest) {
+		tc := s.SessionReq.Plan.Case[0]
+		mreq := &api.ModifySessionRequest{
+			Id:           "this-session-does-not-exist",
+			Modification: api.Modification_MODIFY_TESTCASE,
+			Case:         []*api.Testcase{tc},
+		}
+		resp, err := s.Server.Modify(s.Reqval.GetContext(s.User, types.PermissionSessionModify), mreq)
+		testNegativeResponse(t, "Modify", codes.NotFound, resp == nil, err)
+	}
+	testModification(t, ctrl, mod, func(s *modificationTest) {})
+}
+
+func TestModifyNonExistentTestcase(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mod := func(s *modificationTest) {
+		tc := s.SessionReq.Plan.Case[0]
+		tc.Id = "does-not-exist"
+		mreq := &api.ModifySessionRequest{
+			Id:           s.SessionID,
+			Modification: api.Modification_MODIFY_TESTCASE,
+			Case:         []*api.Testcase{tc},
+		}
+		resp, err := s.Server.Modify(s.Reqval.GetContext(s.User, types.PermissionSessionModify), mreq)
+		testNegativeResponse(t, "Modify", codes.NotFound, resp == nil, err)
+	}
+	testModification(t, ctrl, mod, func(s *modificationTest) {})
+}
+
+func TestModifyToInvalidTestcase(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mod := func(s *modificationTest) {
+		tc := api.Testcase{
+			Id: s.SessionReq.Plan.Case[0].Id,
+		}
+		mreq := &api.ModifySessionRequest{
+			Id:           s.SessionID,
+			Modification: api.Modification_MODIFY_TESTCASE,
+			Case:         []*api.Testcase{&tc},
+		}
+		resp, err := s.Server.Modify(s.Reqval.GetContext(s.User, types.PermissionSessionModify), mreq)
+		testNegativeResponse(t, "Modify", codes.InvalidArgument, resp == nil, err)
+	}
+	testModification(t, ctrl, mod, func(s *modificationTest) {})
+}
+
+func TestModifyInvalidAddTestcase(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mod := func(s *modificationTest) {
+		tc := s.SessionReq.Plan.Case[0]
+		mreq := &api.ModifySessionRequest{
+			Id:           s.SessionID,
+			Modification: api.Modification_ADD_TESTCASE,
+			Case:         []*api.Testcase{tc},
+		}
+		resp, err := s.Server.Modify(s.Reqval.GetContext(s.User, types.PermissionSessionModify), mreq)
+		testNegativeResponse(t, "Modify", codes.AlreadyExists, resp == nil, err)
+	}
+	testModification(t, ctrl, mod, func(s *modificationTest) {})
+}
+
+func TestRemoveNonExistentTestcase(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mod := func(s *modificationTest) {
+		tc := api.Testcase{
+			Id: "does-not-exist",
+		}
+		mreq := &api.ModifySessionRequest{
+			Id:           s.SessionID,
+			Modification: api.Modification_REMOVE_TESTCASE,
+			Case:         []*api.Testcase{&tc},
+		}
+		resp, err := s.Server.Modify(s.Reqval.GetContext(s.User, types.PermissionSessionModify), mreq)
+		testNegativeResponse(t, "Modify", codes.NotFound, resp == nil, err)
+	}
+	testModification(t, ctrl, mod, func(s *modificationTest) {})
+}
+
+type modificationTest struct {
+	Server     api.SessionServiceServer
+	Reqval     *MockValidator
+	SessionReq *api.StartSessionRequest
+	SessionID  string
+	Status     *api.SessionStatusResponse
+	User       string
+}
+
+func testModification(t *testing.T, ctrl *gomock.Controller, mod func(s *modificationTest), validate func(s *modificationTest)) {
+	s, reqval := newTestServer(ctrl)
+
+	user := "user"
+	sreq := validStartSessionRequest()
+	sresp, err := s.Start(reqval.GetContext(user, types.PermissionSessionStart), sreq)
+	if err != nil {
+		t.Errorf("Cannot start session: %v", err)
+		return
+	}
+
+	if _, err := s.Register(reqval.GetContext(user, types.PermissionSessionContribute), validRegistrationRequest(sresp.Id)); err != nil {
+		t.Errorf("Cannot join session: %v", err)
+		return
+	}
+	if _, err := s.Claim(reqval.GetContext(user, types.PermissionSessionContribute), &api.ClaimRequest{Session: sresp.Id, TestcaseID: "tc00", Claim: true}); err != nil {
+		t.Errorf("Cannot claim testcase: %v", err)
+		return
+	}
+	status, err := s.Status(reqval.GetContext(user, types.PermissionSessionView), &api.SessionStatusRequest{Id: sresp.Id})
+	if err != nil || status == nil {
+		t.Errorf("Cannot get status: %v", err)
+		return
+	}
+
+	state := modificationTest{
+		Server:     s,
+		Reqval:     reqval,
+		SessionReq: sreq,
+		SessionID:  sresp.Id,
+		User:       user,
+		Status:     status,
+	}
+	mod(&state)
+
+	status, err = s.Status(reqval.GetContext(user, types.PermissionSessionView), &api.SessionStatusRequest{Id: sresp.Id})
+	if err != nil || status == nil {
+		t.Errorf("Cannot get status: %v", err)
+		return
+	}
+	state.Status = status
+	validate(&state)
+}

--- a/pkg/server/kvsession/serialization.proto
+++ b/pkg/server/kvsession/serialization.proto
@@ -7,6 +7,7 @@ message SessionMetadata {
     string planID = 2;
     bool open = 3;
     map<string, string> annotations = 4;
+    bool modifiable = 5;
 }
 
 message TestplanMetadata {

--- a/pkg/server/kvsession/start_test.go
+++ b/pkg/server/kvsession/start_test.go
@@ -42,6 +42,7 @@ var validStartSessionRequest = func() *api.StartSessionRequest {
 			"commit":  "91816720613ad4ecbd0198246aa6f44c264c129f",
 			"version": "v0.3.0",
 		},
+		Modifiable: true,
 	}
 }
 

--- a/pkg/server/kvsession/status_test.go
+++ b/pkg/server/kvsession/status_test.go
@@ -61,12 +61,15 @@ func TestBasicStatus(t *testing.T) {
 	if status.Open != true {
 		t.Errorf("Status returned wrong open flag: expected %v, actual %v", true, status.Open)
 	}
+	if status.Modifiable != true {
+		t.Errorf("Status returned wrong modifiable flag: expected %v, actual %v", true, status.Modifiable)
+	}
 	if status.State != api.TestRunState_UNDECIDED {
 		t.Errorf("Session without a single run should have \"undecided\" as state, not %s", status.State.String())
 	}
 
-	sort.Slice(status.Status, func(i, j int) bool { return status.Status[i].Case.Id < status.Status[j].Case.Id })
-	for i, tcs := range status.Status {
+	sort.Slice(status.Case, func(i, j int) bool { return status.Case[i].Case.Id < status.Case[j].Case.Id })
+	for i, tcs := range status.Case {
 		orig := sreq.Plan.Case[i]
 		if tcs.Case.Group != orig.Group {
 			t.Errorf("Status returned wrong group for TC %d: expected %s, actual: %s", i, orig.Group, tcs.Case.Group)

--- a/pkg/types/permissions.go
+++ b/pkg/types/permissions.go
@@ -10,6 +10,7 @@ const (
 	PermissionUserChpwd         Permission = "user.chpwd"
 	PermissionUserList          Permission = "user.list"
 	PermissionSessionStart      Permission = "session.start"
+	PermissionSessionModify     Permission = "session.modify"
 	PermissionSessionClose      Permission = "session.close"
 	PermissionSessionView       Permission = "session.view"
 	PermissionSessionContribute Permission = "session.contribute"
@@ -23,6 +24,7 @@ var AllPermissions = []Permission{
 	PermissionUserChpwd,
 	PermissionUserList,
 	PermissionSessionStart,
+	PermissionSessionModify,
 	PermissionSessionClose,
 	PermissionSessionView,
 	PermissionSessionContribute,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -67,7 +67,7 @@ type TestRunStatus struct {
 	// Plan ID is the ID of the testplan being executed
 	PlanID string
 	// Status lists the status for each testcase of the plan
-	Status []TestcaseStatus
+	Cases []TestcaseStatus
 	// State is the overall test run state
 	State TestRunState
 	// Annotations are session metadata


### PR DESCRIPTION
- Sessions can be made modifiable
- Introduced a new permission `session.modify`
- Implemented session modifications (add/remove/modify testcase, change annotations) in the backend, including the new `Modify` RPC call and its unit tests
- Implemented add/modify/remove testcase in the JS client
- Using these capabilities to provide a UI for modifying an ongoing session in the web client. Edit mode can only be enabled on modifiable sessions