### PR TITLE
Fixed session describe

### DIFF
--- a/cmd/sessionDescribe.go
+++ b/cmd/sessionDescribe.go
@@ -17,7 +17,7 @@ Annotations:	{{ range $k, $v := .Annotations }}{{ $k }}:	{{ $v }}
 {{ end }}
 Tests:
 {{- range .Case }}
-  {{ .Case.Id }}:
+  {{ .Case.ID }}:
     Name:	{{ .Case.Name }}
     Result:	{{ .State }}
     Claims:	{{ len .Claim -}}


### PR DESCRIPTION
prior to this PR `ruruku session describe` failed because an the testcase `Id` was renamed to `ID`.